### PR TITLE
Adjust AwesomeVersion to represent the value

### DIFF
--- a/awesomeversion/awesomeversion.py
+++ b/awesomeversion/awesomeversion.py
@@ -18,7 +18,7 @@ class AwesomeVersion(str):
             self._version = version
         if isinstance(self._version, str):
             self._version = self._version.strip()
-        str.__init__(self.string)
+        str.__init__(str(self._version))
 
     def __enter__(self) -> "AwesomeVersion":
         return self
@@ -30,7 +30,7 @@ class AwesomeVersion(str):
         return f"<AwesomeVersion {self.strategy} '{self.string}'>"
 
     def __str__(self) -> str:
-        return self.string
+        return str(self._version)
 
     def __eq__(self, compareto: Union[str, float, int, "AwesomeVersion"]) -> bool:
         """Check if equals to."""

--- a/awesomeversion/match.py
+++ b/awesomeversion/match.py
@@ -12,7 +12,7 @@ RE_SPECIAL_CONTAINER = re.compile(r"^(latest|dev|stable|beta)$")
 RE_SIMPLE = re.compile(r"^[v|V]?((\d+)?\.?)*$")
 
 RE_DIGIT = re.compile(r"[a-z]*(\d+)[a-z]*")
-RE_VERSION = re.compile(r"^([v|V])?(.*)$")
+RE_VERSION = re.compile(r"^(v|V)?(.*)$")
 RE_MODIFIER = re.compile(r"^\d+(([a-z]+)\d+)?$")
 
 

--- a/tests/test_awesomeversion.py
+++ b/tests/test_awesomeversion.py
@@ -31,7 +31,8 @@ def test_awesomeversion():
     version2 = AwesomeVersion(version)
     assert version == version2
 
-    assert str(version) == "2020.12.1rc0"
+    assert str(version) == "v2020.12.1rc0"
+    assert version.string == "2020.12.1rc0"
     assert repr(version) == "<AwesomeVersion CalVer '2020.12.1rc0'>"
 
     with AwesomeVersion("20.12.0") as current:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

It makes that the Object represents on public python interface the real value of itself. If a docker tag order git tag starts with `v`, they would be cut off and also store wrong on json. If we load the value again, we never are able to pull the tag or check out the branch/tag again.

Internal and with `object.string` it would be handle like today, so if we want a different representation on UI, we can use that property, otherwise, if we use it on python, it will represent the origin value.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionalit)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`make black`)
- [x] Tests have been added to verify that the new code works.

