### PR TITLE
Deprecate positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ python3 -m pip install awesomeversion
 
 ## AwesomeVersion class
 
-The AwesomeVersion class takes a version as the first argument, you can also pass in additional arguments to customize the version object.
+The AwesomeVersion class takes a version as the first argument, you can also pass in additional kwargs to customize the version object.
 
 Argument | Description
 --- | ---

--- a/awesomeversion/awesomeversion.py
+++ b/awesomeversion/awesomeversion.py
@@ -1,8 +1,7 @@
 """AwesomeVersion."""
 from __future__ import annotations
 
-from types import TracebackType
-from typing import Any, Type
+from typing import Any
 
 from .comparehandlers.container import compare_handler_container
 from .comparehandlers.modifier import compare_handler_semver_modifier
@@ -46,19 +45,21 @@ class AwesomeVersion(_AwesomeVersionBase):
     """
     AwesomeVersion class.
 
-    version:
-        The version to create a AwesomeVersion object from
+    args:
+        version:
+            The version to create a AwesomeVersion object from
 
-    ensure_strategy:
-        Match the AwesomeVersion object against spesific
-        strategies when creating if. If it does not match
-        AwesomeVersionStrategyException will be raised
+    kwargs:
+        ensure_strategy:
+            Match the AwesomeVersion object against spesific
+            strategies when creating if. If it does not match
+            AwesomeVersionStrategyException will be raised
 
-    find_first_match:
-        If True, the version given will be scanned for the first
-        match of the given ensure_strategy. Raises
-        AwesomeVersionStrategyException If it is not found
-        for any of the given strategies.
+        find_first_match:
+            If True, the version given will be scanned for the first
+            match of the given ensure_strategy. Raises
+            AwesomeVersionStrategyException If it is not found
+            for any of the given strategies.
     """
 
     _version: str = ""
@@ -69,12 +70,22 @@ class AwesomeVersion(_AwesomeVersionBase):
     _ensure_strategy: EnsureStrategyIterableType = []
 
     def __init__(
-        self,
+        self,  # pylint: disable=unused-argument
         version: VersionType,
+        *args: Any,
         ensure_strategy: EnsureStrategyType = None,
         find_first_match: bool = False,
+        **kwargs: Any,
     ) -> None:
         """Initialize AwesomeVersion."""
+        if args:
+            # Allow old-style args
+            # Deprecated, will be removed in future version (sometime after 23.1.0)
+            # Start logging deprecation warning after 22.8.0
+            ensure_strategy = args[0]
+            if len(args) == 2:
+                find_first_match = args[1]
+
         if isinstance(version, AwesomeVersion):
             self._version = version._version
         else:
@@ -115,12 +126,7 @@ class AwesomeVersion(_AwesomeVersionBase):
     def __enter__(self) -> AwesomeVersion:
         return self
 
-    def __exit__(
-        self,
-        exctype: Type[BaseException] | None,
-        excinst: BaseException | None,
-        exctb: TracebackType | None,
-    ) -> bool:
+    def __exit__(self, *_: Any, **__: Any) -> bool:
         pass
 
     def __repr__(self) -> str:

--- a/awesomeversion/awesomeversion.py
+++ b/awesomeversion/awesomeversion.py
@@ -45,21 +45,23 @@ class AwesomeVersion(_AwesomeVersionBase):
     """
     AwesomeVersion class.
 
-    args:
-        version:
-            The version to create a AwesomeVersion object from
+    **args**:
 
-    kwargs:
-        ensure_strategy:
-            Match the AwesomeVersion object against spesific
-            strategies when creating if. If it does not match
-            AwesomeVersionStrategyException will be raised
+    version:
+        The version to create a AwesomeVersion object from
 
-        find_first_match:
-            If True, the version given will be scanned for the first
-            match of the given ensure_strategy. Raises
-            AwesomeVersionStrategyException If it is not found
-            for any of the given strategies.
+    **kwargs**:
+
+    ensure_strategy:
+        Match the AwesomeVersion object against spesific
+        strategies when creating if. If it does not match
+        AwesomeVersionStrategyException will be raised
+
+    find_first_match:
+        If True, the version given will be scanned for the first
+        match of the given ensure_strategy. Raises
+        AwesomeVersionStrategyException If it is not found
+        for any of the given strategies.
     """
 
     _version: str = ""

--- a/awesomeversion/awesomeversion.py
+++ b/awesomeversion/awesomeversion.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from warnings import warn
 
 from .comparehandlers.container import compare_handler_container
 from .comparehandlers.modifier import compare_handler_semver_modifier
@@ -81,11 +82,20 @@ class AwesomeVersion(_AwesomeVersionBase):
     ) -> None:
         """Initialize AwesomeVersion."""
         if args:
-            # Allow old-style args
-            # Deprecated, will be removed in future version (sometime after 23.1.0)
-            # Start logging deprecation warning after 22.8.0
+            warn(
+                "Positional argument for ensure_strategy is deprecated. "
+                "This will be removed in 2023, use keyword argument instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             ensure_strategy = args[0]
             if len(args) == 2:
+                warn(
+                    "Positional argument for find_first_match is deprecated. "
+                    "This will be removed in 2023, use keyword argument instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 find_first_match = args[1]
 
         if isinstance(version, AwesomeVersion):

--- a/tests/test_awesomeversion.py
+++ b/tests/test_awesomeversion.py
@@ -211,3 +211,4 @@ def test_find_first_match(
         find_first_match=True,
     )
     assert obj.string == result
+    assert AwesomeVersion(version, strategy, True).string == obj.string


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Passing positional arguments for `ensure_strategy` and `find_first_match` is now deprecated.
For now, it will still work, a warning will be added later this year, and it will be removed next year.

This means that you should refactor your code to use keyword arguments instead.

Before:
```python
AwesomeVersion("1.2.3", "semver", False)
```

After:
```python
AwesomeVersion("1.2.3", ensure_strategy="semver", find_first_match=False)
# or
AwesomeVersion(version="1.2.3", ensure_strategy="semver", find_first_match=False)
```
## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionalit)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`make black`)
- [ ] Tests have been added to verify that the new code works.

