### PR TITLE
Refactor coverage workflow to use codecov/codecov-action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -104,7 +104,12 @@ jobs:
       - name: 📦 Install dependencies
         run: script/bootstrap
 
+      - name: 📤 Generate coverage report
+        run: script/coverage
+
       - name: 📤 Upload coverage to Codecov
-        run: |
-          script/coverage
-          curl -sfSL https://codecov.io/bash | bash -
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## What does this PR do?

Refactors the coverage upload workflow to use the official `codecov/codecov-action` GitHub Action instead of manually running the coverage script and curl command. This improves reliability and maintainability by using the officially supported integration.

## Type of change (pick one)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔨 Code improvement or refactor
- [ ] 📦 Dependency update
- [ ] 💥 Breaking change

## Related issues or links

N/A

## Changes

- Separated coverage report generation into its own step (`script/coverage`)
- Replaced manual curl-based Codecov upload with `codecov/codecov-action@v7.0.0`
- Added explicit configuration for token, coverage file path, and CI failure handling
- Improved workflow clarity by splitting concerns into distinct steps

## Checklist

- [x] I tested my changes locally
- [x] All tests pass
- [x] No commented-out code left
- [x] Code is formatted (run `script/lint`)
- [x] Added or updated tests if needed

https://claude.ai/code/session_017hvyBytnVpJYhhX2Ps5Rcq