### PR TITLE
Fix alpha and dev version detection logic

### DIFF
--- a/awesomeversion/awesomeversion.py
+++ b/awesomeversion/awesomeversion.py
@@ -261,7 +261,7 @@ class AwesomeVersion(str):
     @property
     def alpha(self) -> bool:
         """Return a bool to indicate alpha version."""
-        return "a" in self.modifier if self.modifier else False
+        return self.modifier_type in ("a", "alpha")
 
     @property
     def beta(self) -> bool:
@@ -271,7 +271,11 @@ class AwesomeVersion(str):
     @property
     def dev(self) -> bool:
         """Return a bool to indicate dev version."""
-        return "d" in self.modifier if self.modifier else "dev" in self.string
+        return (
+            self.modifier_type in ("d", "dev")
+            if self.modifier
+            else "dev" in self.string
+        )
 
     @property
     def release_candidate(self) -> bool:

--- a/tests/snapshots/PEP 440/1.0.0beta0.json
+++ b/tests/snapshots/PEP 440/1.0.0beta0.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta.1.json
+++ b/tests/snapshots/SemVer/1.0.0-beta.1.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta.10.json
+++ b/tests/snapshots/SemVer/1.0.0-beta.10.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta.2.json
+++ b/tests/snapshots/SemVer/1.0.0-beta.2.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta.9.json
+++ b/tests/snapshots/SemVer/1.0.0-beta.9.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta.json
+++ b/tests/snapshots/SemVer/1.0.0-beta.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta0.json
+++ b/tests/snapshots/SemVer/1.0.0-beta0.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.0.0-beta1.json
+++ b/tests/snapshots/SemVer/1.0.0-beta1.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.8.2-beta.1.10+somebuild.json
+++ b/tests/snapshots/SemVer/1.8.2-beta.1.10+somebuild.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.8.2-beta.1.10.json
+++ b/tests/snapshots/SemVer/1.8.2-beta.1.10.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/1.8.2-beta.1.13.json
+++ b/tests/snapshots/SemVer/1.8.2-beta.1.13.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "1",

--- a/tests/snapshots/SemVer/2.0.0-beta.1.json
+++ b/tests/snapshots/SemVer/2.0.0-beta.1.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "2",

--- a/tests/snapshots/SemVer/2.0.0-beta.2.json
+++ b/tests/snapshots/SemVer/2.0.0-beta.2.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "2",

--- a/tests/snapshots/SemVer/3.0.0-beta.1.json
+++ b/tests/snapshots/SemVer/3.0.0-beta.1.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "3",

--- a/tests/snapshots/SemVer/3.0.0-beta.2.json
+++ b/tests/snapshots/SemVer/3.0.0-beta.2.json
@@ -1,5 +1,5 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": true,
     "dev": false,
     "major": "3",

--- a/tests/snapshots/unknown/1.0.invalid4.json
+++ b/tests/snapshots/unknown/1.0.invalid4.json
@@ -1,7 +1,7 @@
 {
-    "alpha": true,
+    "alpha": false,
     "beta": false,
-    "dev": true,
+    "dev": false,
     "major": null,
     "micro": null,
     "minor": null,

--- a/tests/test_awesomeversion.py
+++ b/tests/test_awesomeversion.py
@@ -49,6 +49,7 @@ def test_awesomeversion() -> None:
 
     version = AwesomeVersion("1.0.0-build3")
     assert not version.dev
+    assert not version.beta
 
     version = AwesomeVersion("2020.12.1rc0")
     assert version.release_candidate

--- a/tests/test_awesomeversion.py
+++ b/tests/test_awesomeversion.py
@@ -42,6 +42,14 @@ def test_awesomeversion() -> None:
     assert version.dev
     assert version.valid
 
+    # A beta is not an alpha, and a build is not a dev version.
+    version = AwesomeVersion("1.0.0-beta.2")
+    assert not version.alpha
+    assert version.beta
+
+    version = AwesomeVersion("1.0.0-build3")
+    assert not version.dev
+
     version = AwesomeVersion("2020.12.1rc0")
     assert version.release_candidate
     assert version.prefix is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.16" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.3.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
-    { name = "pytest-codspeed", marker = "extra == 'dev'", specifier = ">=3.2.0" },
+    { name = "pytest-codspeed", marker = "extra == 'dev'", specifier = "==4.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
     { name = "pytest-snapshot", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
@@ -509,7 +509,7 @@ wheels = [
 
 [[package]]
 name = "pytest-codspeed"
-version = "3.2.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
@@ -517,19 +517,23 @@ dependencies = [
     { name = "pytest" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/98/16fe3895b1b8a6d537a89eecb120b97358df8f0002c6ecd11555d6304dc8/pytest_codspeed-3.2.0.tar.gz", hash = "sha256:f9d1b1a3b2c69cdc0490a1e8b1ced44bffbd0e8e21d81a7160cfdd923f6e8155", size = 18409, upload-time = "2025-01-31T14:28:26.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/27fcbe6516a1c956614a4b61a7fccbf3791ea0b992e07416e8948184327d/pytest_codspeed-4.2.0.tar.gz", hash = "sha256:04b5d0bc5a1851ba1504d46bf9d7dbb355222a69f2cd440d54295db721b331f7", size = 113263, upload-time = "2025-10-24T09:02:55.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/31/62b93ee025ca46016d01325f58997d32303752286bf929588c8796a25b13/pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5165774424c7ab8db7e7acdb539763a0e5657996effefdf0664d7fd95158d34", size = 26802, upload-time = "2025-01-31T14:28:10.723Z" },
-    { url = "https://files.pythonhosted.org/packages/89/60/2bc46bdf8c8ddb7e59cd9d480dc887d0ac6039f88c856d1ae3d29a4e648d/pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bd55f92d772592c04a55209950c50880413ae46876e66bd349ef157075ca26c", size = 25442, upload-time = "2025-01-31T14:28:11.774Z" },
-    { url = "https://files.pythonhosted.org/packages/31/56/1b65ba0ae1af7fd7ce14a66e7599833efe8bbd0fcecd3614db0017ca224a/pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cf6f56067538f4892baa8d7ab5ef4e45bb59033be1ef18759a2c7fc55b32035", size = 26810, upload-time = "2025-01-31T14:28:12.657Z" },
-    { url = "https://files.pythonhosted.org/packages/23/e6/d1fafb09a1c4983372f562d9e158735229cb0b11603a61d4fad05463f977/pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a687b05c3d145642061b45ea78e47e12f13ce510104d1a2cda00eee0e36f58", size = 25442, upload-time = "2025-01-31T14:28:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/8b/9e95472589d17bb68960f2a09cfa8f02c4d43c82de55b73302bbe0fa4350/pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46a1afaaa1ac4c2ca5b0700d31ac46d80a27612961d031067d73c6ccbd8d3c2b", size = 27182, upload-time = "2025-01-31T14:28:15.828Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/18/82aaed8095e84d829f30dda3ac49fce4e69685d769aae463614a8d864cdd/pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c48ce3af3dfa78413ed3d69d1924043aa1519048dbff46edccf8f35a25dab3c2", size = 25933, upload-time = "2025-01-31T14:28:17.151Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/15/60b18d40da66e7aa2ce4c4c66d5a17de20a2ae4a89ac09a58baa7a5bc535/pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66692506d33453df48b36a84703448cb8b22953eea51f03fbb2eb758dc2bdc4f", size = 27180, upload-time = "2025-01-31T14:28:18.056Z" },
-    { url = "https://files.pythonhosted.org/packages/51/bd/6b164d4ae07d8bea5d02ad664a9762bdb63f83c0805a3c8fe7dc6ec38407/pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:479774f80d0bdfafa16112700df4dbd31bf2a6757fac74795fd79c0a7b3c389b", size = 25923, upload-time = "2025-01-31T14:28:19.725Z" },
-    { url = "https://files.pythonhosted.org/packages/90/bb/5d73c59d750264863c25fc202bcc37c5f8a390df640a4760eba54151753e/pytest_codspeed-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:109f9f4dd1088019c3b3f887d003b7d65f98a7736ca1d457884f5aa293e8e81c", size = 26795, upload-time = "2025-01-31T14:28:22.021Z" },
-    { url = "https://files.pythonhosted.org/packages/65/17/d4bf207b63f1edc5b9c06ad77df565d186e0fd40f13459bb124304b54b1d/pytest_codspeed-3.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2f69a03b52c9bb041aec1b8ee54b7b6c37a6d0a948786effa4c71157765b6da", size = 25433, upload-time = "2025-01-31T14:28:22.955Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9b/952c70bd1fae9baa58077272e7f191f377c86d812263c21b361195e125e6/pytest_codspeed-3.2.0-py3-none-any.whl", hash = "sha256:54b5c2e986d6a28e7b0af11d610ea57bd5531cec8326abe486f1b55b09d91c39", size = 15007, upload-time = "2025-01-31T14:28:24.458Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b8/d599a466c50af3f04001877ae8b17c12b803f3b358235736b91a0769de0d/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609828b03972966b75b9b7416fa2570c4a0f6124f67e02d35cd3658e64312a7b", size = 261943, upload-time = "2025-10-24T09:02:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/74/19/ccc1a2fcd28357a8db08ba6b60f381832088a3850abc262c8e0b3406491a/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23a0c0fbf8bb4de93a3454fd9e5efcdca164c778aaef0a9da4f233d85cb7f5b8", size = 250782, upload-time = "2025-10-24T09:02:39.617Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2d/f0083a2f14ecf008d961d40439a71da0ae0d568e5f8dc2fccd3e8a2ab3e4/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2de87bde9fbc6fd53f0fd21dcf2599c89e0b8948d49f9bad224edce51c47e26b", size = 261960, upload-time = "2025-10-24T09:02:40.665Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0c/1f514c553db4ea5a69dfbe2706734129acd0eca8d5101ec16f1dd00dbc0f/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95aeb2479ca383f6b18e2cc9ebcd3b03ab184980a59a232aea6f370bbf59a1e3", size = 250808, upload-time = "2025-10-24T09:02:42.07Z" },
+    { url = "https://files.pythonhosted.org/packages/81/04/479905bd6653bc981c0554fcce6df52d7ae1594e1eefd53e6cf31810ec7f/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d4fefbd4ae401e2c60f6be920a0be50eef0c3e4a1f0a1c83962efd45be38b39", size = 262084, upload-time = "2025-10-24T09:02:43.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/46/d6f345d7907bac6cbb6224bd697ecbc11cf7427acc9e843c3618f19e3476/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:309b4227f57fcbb9df21e889ea1ae191d0d1cd8b903b698fdb9ea0461dbf1dfe", size = 251100, upload-time = "2025-10-24T09:02:44.168Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/e864f45e994a50390ff49792256f1bdcbf42f170e3bc0470ee1a7d2403f3/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72aab8278452a6d020798b9e4f82780966adb00f80d27a25d1274272c54630d5", size = 262057, upload-time = "2025-10-24T09:02:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1c/f1d2599784486879cf6579d8d94a3e22108f0e1f130033dab8feefd29249/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:684fcd9491d810ded653a8d38de4835daa2d001645f4a23942862950664273f8", size = 251013, upload-time = "2025-10-24T09:02:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fd/eafd24db5652a94b4d00fe9b309b607de81add0f55f073afb68a378a24b6/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50794dabea6ec90d4288904452051e2febace93e7edf4ca9f2bce8019dd8cd37", size = 262065, upload-time = "2025-10-24T09:02:48.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/14/8d9340d7dc0ae647991b28a396e16b3403e10def883cde90d6b663d3f7ec/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0ebd87f2a99467a1cfd8e83492c4712976e43d353ee0b5f71cbb057f1393aca", size = 251057, upload-time = "2025-10-24T09:02:49.102Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/48cf6afbca55bc7c8c93c3d4ae926a1068bcce3f0241709db19b078d5418/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbbb2d61b85bef8fc7e2193f723f9ac2db388a48259d981bbce96319043e9830", size = 267983, upload-time = "2025-10-24T09:02:50.558Z" },
+    { url = "https://files.pythonhosted.org/packages/33/86/4407341efb5dceb3e389635749ce1d670542d6ca148bd34f9d5334295faf/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:748411c832147bfc85f805af78a1ab1684f52d08e14aabe22932bbe46c079a5f", size = 256732, upload-time = "2025-10-24T09:02:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/60/c395c19c14a1345d41ac3f7f0a9b372b666e88f9ba1f71988215174882bb/pytest_codspeed-4.2.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:238e17abe8f08d8747fa6c7acff34fefd3c40f17a56a7847ca13dc8d6e8c6009", size = 261935, upload-time = "2025-10-24T09:02:52.702Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ed/442fb6a1832c2c9002653f24770873839b24c091bd2ed658090c7862c563/pytest_codspeed-4.2.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0881a736285f33b9a8894da8fe8e1775aa1a4310226abe5d1f0329228efb680c", size = 250770, upload-time = "2025-10-24T09:02:53.73Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/8cb71fd3ed4ed08c07aec1245aea7bc1b661ba55fd9c392db76f1978d453/pytest_codspeed-4.2.0-py3-none-any.whl", hash = "sha256:e81bbb45c130874ef99aca97929d72682733527a49f84239ba575b5cb843bab0", size = 113726, upload-time = "2025-10-24T09:02:54.785Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Fixes the `alpha` and `dev` version detection properties to use `modifier_type` instead of substring matching, preventing false positives where beta versions were incorrectly identified as alpha and build versions as dev.

## Type of change (pick one)

- [x] 🐛 Bug fix

## Related issues or links

The changes fix incorrect version classification where:
- Beta versions (e.g., "1.0.0-beta.2") were incorrectly flagged as alpha
- Build versions (e.g., "1.0.0-build3") were incorrectly flagged as dev

## Details

**Changes to `awesomeversion.py`:**
- `alpha` property: Changed from substring matching (`"a" in self.modifier`) to explicit type checking (`self.modifier_type in ("a", "alpha")`)
- `dev` property: Changed from substring matching (`"d" in self.modifier`) to explicit type checking (`self.modifier_type in ("d", "dev")`)

These changes ensure that version classification is based on the actual modifier type rather than loose substring matching, which was causing false positives.

**Test updates:**
- Added explicit test cases verifying that beta versions are not alpha and build versions are not dev
- Updated snapshot tests to reflect the corrected behavior

## Checklist

- [x] I tested my changes locally
- [x] All tests pass
- [x] No commented-out code left
- [x] Code is formatted
- [x] Added tests to verify the fix

https://claude.ai/code/session_019rKEm9kHfoeDB2v7qcEMaE